### PR TITLE
chore: move api to api.thegoat.ir

### DIFF
--- a/pages/domain/_name.vue
+++ b/pages/domain/_name.vue
@@ -38,7 +38,7 @@ export default {
   async fetch() {
     if (this.$route.params.name !== undefined) {
       this.info = await this.$http.$get(
-        `https://api.mahdyar.me/whois/lookup?token=${this.apiToken}&domain=${this.$route.params.name}`
+        `https://api.thegoat.ir/whois/lookup?token=${this.apiToken}&domain=${this.$route.params.name}`
       );
     }
   },


### PR DESCRIPTION
Closes #1 

Note: `api.mahdyar.me` will still be responding to the whois lookup requests until `1/5/2021`.